### PR TITLE
Add WooCommerce fabric mockup generator plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# aiimage
+# WooCommerce Fabric Mockups
+
+WordPress plugin that generates studio mockup images of a chair with different fabrics using OpenAI DALL·E 3 image edits. It automatically creates WooCommerce product variations with the generated images.

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -1,0 +1,52 @@
+jQuery(function($){
+    var frame;
+    $('#wcfm_upload_texture').on('click', function(e){
+        e.preventDefault();
+        if ( frame ) {
+            frame.open();
+            return;
+        }
+        frame = wp.media({
+            title: 'Select fabric texture',
+            button: { text: 'Use this texture' },
+            library: { type: 'image' }
+        });
+        frame.on('select', function(){
+            var attachment = frame.state().get('selection').first().toJSON();
+            $('#wcfm_texture_id').val( attachment.id );
+        });
+        frame.open();
+    });
+
+    $('#wcfm_generate').on('click', function(){
+        var fabric = $('#wcfm_fabric_name').val();
+        var tex = $('#wcfm_texture_id').val();
+        var allAngles = $('#wcfm_all_angles').is(':checked');
+        if ( ! fabric || ! tex ) {
+            alert('Please provide fabric name and upload texture.');
+            return;
+        }
+        var btn = $(this).prop('disabled', true);
+        fetch(WCFM.rest_url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-WP-Nonce': WCFM.nonce
+            },
+            body: JSON.stringify({
+                product_id: WCFM.product_id,
+                fabric_name: fabric,
+                texture_id: tex,
+                all_angles: allAngles ? 1 : 0
+            })
+        }).then(function(resp){
+            return resp.json();
+        }).then(function(){
+            alert('Generation scheduled.');
+            btn.prop('disabled', false);
+        }).catch(function(){
+            alert('Error scheduling generation');
+            btn.prop('disabled', false);
+        });
+    });
+});

--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -1,0 +1,104 @@
+<?php
+namespace WC_Fabric_Mockups;
+
+use WP_Post;
+
+class Admin {
+    public static function init() {
+        add_action( 'add_meta_boxes', [ __CLASS__, 'register_metabox' ] );
+        add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue' ] );
+        add_action( 'admin_menu', [ __CLASS__, 'settings_menu' ] );
+        add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
+    }
+
+    public static function register_metabox() {
+        add_meta_box( 'wcfm_fabric_mockups', __( 'Fabric Mockups', 'wcfm' ), [ __CLASS__, 'render_metabox' ], 'product', 'side' );
+    }
+
+    public static function render_metabox( WP_Post $post ) {
+        wp_nonce_field( 'wcfm_metabox', 'wcfm_nonce' );
+        ?>
+        <p>
+            <label for="wcfm_fabric_name"><?php _e( 'Fabric name', 'wcfm' ); ?></label>
+            <input type="text" id="wcfm_fabric_name" class="widefat" />
+        </p>
+        <p>
+            <label><?php _e( 'Fabric texture', 'wcfm' ); ?></label><br/>
+            <input type="hidden" id="wcfm_texture_id" />
+            <button type="button" class="button" id="wcfm_upload_texture"><?php _e( 'Upload/Select', 'wcfm' ); ?></button>
+        </p>
+        <p>
+            <label><input type="checkbox" id="wcfm_all_angles" checked /> <?php _e( 'Generate all 6 angles', 'wcfm' ); ?></label>
+        </p>
+        <p>
+            <button type="button" class="button button-primary" id="wcfm_generate"><?php _e( 'Generate mockups', 'wcfm' ); ?></button>
+        </p>
+        <?php
+    }
+
+    public static function enqueue( $hook ) {
+        if ( in_array( $hook, [ 'post.php', 'post-new.php' ], true ) ) {
+            $screen = get_current_screen();
+            if ( 'product' !== $screen->post_type ) {
+                return;
+            }
+            wp_enqueue_media();
+            wp_enqueue_script( 'wcfm-admin', WCFM_PLUGIN_URL . 'assets/admin.js', [ 'jquery' ], '1.0', true );
+            wp_localize_script( 'wcfm-admin', 'WCFM', [
+                'nonce'    => wp_create_nonce( 'wcfm_generate' ),
+                'rest_url' => rest_url( 'wc-fabric-mockups/v1/generate' ),
+                'product_id' => get_the_ID(),
+            ] );
+        }
+    }
+
+    public static function settings_menu() {
+        add_options_page( 'Fabric Mockups', 'Fabric Mockups', 'manage_options', 'wcfm-settings', [ __CLASS__, 'render_settings' ] );
+    }
+
+    public static function register_settings() {
+        // API key stored with autoload = no
+        if ( false === get_option( 'wcfm_api_key', false ) ) {
+            add_option( 'wcfm_api_key', '', '', 'no' );
+        }
+        register_setting( 'wcfm-settings', 'wcfm_api_key', [ 'sanitize_callback' => 'sanitize_text_field' ] );
+        register_setting( 'wcfm-settings', 'wcfm_master_image', [ 'sanitize_callback' => 'absint' ] );
+        register_setting( 'wcfm-settings', 'wcfm_mask_image', [ 'sanitize_callback' => 'absint' ] );
+    }
+
+    public static function render_settings() {
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Fabric Mockups Settings', 'wcfm' ); ?></h1>
+            <form method="post" action="options.php">
+                <?php
+                settings_fields( 'wcfm-settings' );
+                ?>
+                <table class="form-table" role="presentation">
+                    <tr>
+                        <th scope="row"><label for="wcfm_api_key"><?php _e( 'OpenAI API Key', 'wcfm' ); ?></label></th>
+                        <td><input type="text" name="wcfm_api_key" id="wcfm_api_key" value="<?php echo esc_attr( get_option( 'wcfm_api_key' ) ); ?>" class="regular-text" /></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="wcfm_master_image"><?php _e( 'Master chair image', 'wcfm' ); ?></label></th>
+                        <td>
+                            <?php $master = get_option( 'wcfm_master_image' ); ?>
+                            <input type="number" name="wcfm_master_image" id="wcfm_master_image" value="<?php echo esc_attr( $master ); ?>" />
+                            <p class="description"><?php _e( 'Attachment ID of the base chair image.', 'wcfm' ); ?></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="wcfm_mask_image"><?php _e( 'Mask image', 'wcfm' ); ?></label></th>
+                        <td>
+                            <?php $mask = get_option( 'wcfm_mask_image' ); ?>
+                            <input type="number" name="wcfm_mask_image" id="wcfm_mask_image" value="<?php echo esc_attr( $mask ); ?>" />
+                            <p class="description"><?php _e( 'Attachment ID of PNG mask with transparent upholstery.', 'wcfm' ); ?></p>
+                        </td>
+                    </tr>
+                </table>
+                <?php submit_button(); ?>
+            </form>
+        </div>
+        <?php
+    }
+}

--- a/inc/ApiAdapter.php
+++ b/inc/ApiAdapter.php
@@ -1,0 +1,71 @@
+<?php
+namespace WC_Fabric_Mockups;
+
+class ApiAdapter {
+    protected $api_key;
+    protected $master_image;
+    protected $mask_image;
+
+    public function __construct( $api_key, $master_image, $mask_image ) {
+        $this->api_key      = $api_key;
+        $this->master_image = $master_image;
+        $this->mask_image   = $mask_image;
+    }
+
+    public function generate( $texture_path, $angle ) {
+        $prompt = sprintf( 'High-end studio photo of the same dining chair model, angle: %s, replace upholstery with fabric from the reference texture image, seamless light gray background with soft shadows.', $angle );
+        $body   = [
+            'prompt' => $prompt,
+            'size'   => '1024x1024',
+        ];
+
+        $boundary = wp_generate_password( 24, false );
+        $headers  = [
+            'Authorization' => 'Bearer ' . $this->api_key,
+            'Content-Type'  => 'multipart/form-data; boundary=' . $boundary,
+        ];
+
+        $files = [
+            'image'       => $this->master_image,
+            'mask'        => $this->mask_image,
+            'image[]'     => $texture_path,
+        ];
+
+        $payload = self::build_multipart( $body, $files, $boundary );
+
+        $response = wp_remote_post( 'https://api.openai.com/v1/images/edits', [
+            'headers' => $headers,
+            'body'    => $payload,
+            'timeout' => 60,
+        ] );
+
+        if ( is_wp_error( $response ) ) {
+            return false;
+        }
+
+        $data = json_decode( wp_remote_retrieve_body( $response ), true );
+        if ( empty( $data['data'][0]['b64_json'] ) ) {
+            return false;
+        }
+        return base64_decode( $data['data'][0]['b64_json'] );
+    }
+
+    protected static function build_multipart( $fields, $files, $boundary ) {
+        $eol = "\r\n";
+        $data = '';
+        foreach ( $fields as $name => $value ) {
+            $data .= "--{$boundary}{$eol}";
+            $data .= "Content-Disposition: form-data; name=\"{$name}\"{$eol}{$eol}{$value}{$eol}";
+        }
+        foreach ( $files as $name => $path ) {
+            $filename = basename( $path );
+            $contents = file_get_contents( $path );
+            $data .= "--{$boundary}{$eol}";
+            $data .= "Content-Disposition: form-data; name=\"{$name}\"; filename=\"{$filename}\"{$eol}";
+            $data .= "Content-Type: image/png{$eol}{$eol}";
+            $data .= $contents . $eol;
+        }
+        $data .= "--{$boundary}--{$eol}";
+        return $data;
+    }
+}

--- a/inc/Generator.php
+++ b/inc/Generator.php
@@ -1,0 +1,71 @@
+<?php
+namespace WC_Fabric_Mockups;
+
+class Generator {
+    const ACTION = 'wcfm_generate_task';
+
+    public static function init() {
+        add_action( self::ACTION, [ __CLASS__, 'process' ], 10, 1 );
+    }
+
+    /**
+     * Schedule generation
+     */
+    public static function queue( $product_id, $fabric_name, $texture_id, $angles ) {
+        as_enqueue_async_action( self::ACTION, [
+            'product_id'  => $product_id,
+            'fabric_name' => $fabric_name,
+            'texture_id'  => $texture_id,
+            'angles'      => $angles,
+        ] );
+    }
+
+    /**
+     * Process scheduled action
+     */
+    public static function process( $args ) {
+        $product_id  = $args['product_id'];
+        $fabric_name = $args['fabric_name'];
+        $texture_id  = $args['texture_id'];
+        $angles      = $args['angles'];
+
+        $api_key = get_option( 'wcfm_api_key' );
+        $master_id = get_option( 'wcfm_master_image' );
+        $mask_id = get_option( 'wcfm_mask_image' );
+
+        $master_path = get_attached_file( $master_id );
+        $mask_path   = get_attached_file( $mask_id );
+        $texture_path = get_attached_file( $texture_id );
+
+        $adapter = new ApiAdapter( $api_key, $master_path, $mask_path );
+        $image_ids = [];
+
+        foreach ( $angles as $angle ) {
+            $data = $adapter->generate( $texture_path, $angle );
+            if ( ! $data ) {
+                continue;
+            }
+
+            $upload_dir = wp_upload_dir();
+            $filename   = 'mockup-' . sanitize_title( $fabric_name . '-' . $angle ) . '.png';
+            $filepath   = $upload_dir['path'] . '/' . $filename;
+            file_put_contents( $filepath, $data );
+
+            $attachment = [
+                'post_mime_type' => 'image/png',
+                'post_title'     => $fabric_name . ' ' . $angle,
+                'post_content'   => '',
+                'post_status'    => 'inherit',
+            ];
+            $attach_id = wp_insert_attachment( $attachment, $filepath );
+            require_once ABSPATH . 'wp-admin/includes/image.php';
+            $metadata = wp_generate_attachment_metadata( $attach_id, $filepath );
+            wp_update_attachment_metadata( $attach_id, $metadata );
+            $image_ids[] = $attach_id;
+        }
+
+        if ( $image_ids ) {
+            Woo::create_variation( $product_id, $fabric_name, $image_ids );
+        }
+    }
+}

--- a/inc/Rest.php
+++ b/inc/Rest.php
@@ -1,0 +1,36 @@
+<?php
+namespace WC_Fabric_Mockups;
+
+class Rest {
+    public static function init() {
+        add_action( 'rest_api_init', [ __CLASS__, 'register_routes' ] );
+    }
+
+    public static function register_routes() {
+        register_rest_route( 'wc-fabric-mockups/v1', '/generate', [
+            'methods'             => 'POST',
+            'permission_callback' => function () {
+                return current_user_can( 'manage_woocommerce' );
+            },
+            'callback'            => [ __CLASS__, 'handle_generate' ],
+        ] );
+    }
+
+    public static function handle_generate( $request ) {
+        $nonce = $request->get_header( 'X-WP-Nonce' );
+        if ( ! wp_verify_nonce( $nonce, 'wcfm_generate' ) ) {
+            return new \WP_Error( 'wcfm_nonce', __( 'Invalid nonce', 'wcfm' ), [ 'status' => 403 ] );
+        }
+
+        $product_id  = intval( $request['product_id'] );
+        $fabric_name = sanitize_text_field( $request['fabric_name'] );
+        $texture_id  = intval( $request['texture_id'] );
+        $all         = ! empty( $request['all_angles'] );
+
+        $angles = $all ? [ 'front', 'front-left', 'left', 'back', 'right', 'front-right' ] : [ 'front' ];
+
+        Generator::queue( $product_id, $fabric_name, $texture_id, $angles );
+
+        return [ 'scheduled' => true ];
+    }
+}

--- a/inc/Woo.php
+++ b/inc/Woo.php
@@ -1,0 +1,66 @@
+<?php
+namespace WC_Fabric_Mockups;
+
+use WC_Product_Variable;
+use WC_Product_Variation;
+
+class Woo {
+    const ATTRIBUTE_SLUG = 'tkanina';
+    const ATTRIBUTE_NAME = 'Tkanina';
+
+    public static function init() {}
+
+    /**
+     * Create or update variation with generated images
+     */
+    public static function create_variation( $product_id, $fabric_name, $image_ids ) {
+        $product = wc_get_product( $product_id );
+        if ( ! $product || ! $product->is_type( 'variable' ) ) {
+            return;
+        }
+
+        self::ensure_attribute( $product, $fabric_name );
+
+        $variation = new WC_Product_Variation();
+        $variation->set_parent_id( $product_id );
+        $variation->set_attributes( [ self::ATTRIBUTE_SLUG => sanitize_title( $fabric_name ) ] );
+        $variation->set_image_id( $image_ids[0] );
+        if ( count( $image_ids ) > 1 ) {
+            $variation->set_gallery_image_ids( array_slice( $image_ids, 1 ) );
+        }
+        $variation->save();
+    }
+
+    protected static function ensure_attribute( WC_Product_Variable $product, $fabric_name ) {
+        $attributes = $product->get_attributes();
+        if ( ! isset( $attributes[ self::ATTRIBUTE_SLUG ] ) ) {
+            $taxonomy = wc_sanitize_taxonomy_name( self::ATTRIBUTE_SLUG );
+            if ( ! taxonomy_exists( $taxonomy ) ) {
+                register_taxonomy( $taxonomy, [ 'product' ], [
+                    'hierarchical' => false,
+                    'label'        => self::ATTRIBUTE_NAME,
+                    'query_var'    => true,
+                ] );
+            }
+            $attribute = new \WC_Product_Attribute();
+            $attribute->set_name( $taxonomy );
+            $attribute->set_options( [] );
+            $attribute->set_visible( true );
+            $attribute->set_variation( true );
+            $attributes[ self::ATTRIBUTE_SLUG ] = $attribute;
+            $product->set_attributes( $attributes );
+            $product->save();
+        }
+
+        if ( ! term_exists( $fabric_name, self::ATTRIBUTE_SLUG ) ) {
+            wp_insert_term( $fabric_name, self::ATTRIBUTE_SLUG );
+        }
+
+        // Ensure term assigned to product
+        $terms = wp_get_object_terms( $product->get_id(), self::ATTRIBUTE_SLUG, [ 'fields' => 'ids' ] );
+        $term = get_term_by( 'name', $fabric_name, self::ATTRIBUTE_SLUG );
+        if ( $term && ! in_array( $term->term_id, $terms, true ) ) {
+            wp_set_object_terms( $product->get_id(), $term->term_id, self::ATTRIBUTE_SLUG, true );
+        }
+    }
+}

--- a/wc-fabric-mockups.php
+++ b/wc-fabric-mockups.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Plugin Name: WooCommerce Fabric Mockups
+ * Description: Generate chair fabric mockup images using OpenAI DALL·E and create WooCommerce variations.
+ * Version: 1.0.0
+ * Author: ChatGPT
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+// Define plugin paths
+define( 'WCFM_PLUGIN_FILE', __FILE__ );
+define( 'WCFM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'WCFM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+// Include required files
+require_once WCFM_PLUGIN_DIR . 'inc/Admin.php';
+require_once WCFM_PLUGIN_DIR . 'inc/Generator.php';
+require_once WCFM_PLUGIN_DIR . 'inc/Woo.php';
+require_once WCFM_PLUGIN_DIR . 'inc/Rest.php';
+require_once WCFM_PLUGIN_DIR . 'inc/ApiAdapter.php';
+
+/**
+ * Bootstrap the plugin
+ */
+function wcfm_init() {
+    \WC_Fabric_Mockups\Woo::init();
+    \WC_Fabric_Mockups\Generator::init();
+    \WC_Fabric_Mockups\Rest::init();
+
+    if ( is_admin() ) {
+        \WC_Fabric_Mockups\Admin::init();
+    }
+}
+add_action( 'plugins_loaded', 'wcfm_init' );


### PR DESCRIPTION
## Summary
- add plugin to generate chair fabric mockups with OpenAI DALL·E
- include admin metabox and settings for API key and images
- create WooCommerce variations with generated images using Action Scheduler

## Testing
- `php -l wc-fabric-mockups.php`
- `php -l inc/Admin.php`
- `php -l inc/Generator.php`
- `php -l inc/Woo.php`
- `php -l inc/Rest.php`
- `php -l inc/ApiAdapter.php`


------
https://chatgpt.com/codex/tasks/task_b_689b7e0bd9fc832281bf44bdacecfea4