### PR TITLE
Add server-side logging for image generation

### DIFF
--- a/inc/ApiAdapter.php
+++ b/inc/ApiAdapter.php
@@ -33,6 +33,10 @@ class ApiAdapter {
 
         $payload = self::build_multipart( $body, $files, $boundary );
 
+        $logger  = wc_get_logger();
+        $context = [ 'source' => 'wc-fabric-mockups' ];
+        $logger->info( 'Calling OpenAI API for angle ' . $angle, $context );
+
         $response = wp_remote_post( 'https://api.openai.com/v1/images/edits', [
             'headers' => $headers,
             'body'    => $payload,
@@ -40,13 +44,16 @@ class ApiAdapter {
         ] );
 
         if ( is_wp_error( $response ) ) {
+            $logger->error( 'OpenAI API error for angle ' . $angle . ': ' . $response->get_error_message(), $context );
             return false;
         }
 
         $data = json_decode( wp_remote_retrieve_body( $response ), true );
         if ( empty( $data['data'][0]['b64_json'] ) ) {
+            $logger->error( 'OpenAI API returned no image data for angle ' . $angle, $context );
             return false;
         }
+        $logger->info( 'Received image data for angle ' . $angle, $context );
         return base64_decode( $data['data'][0]['b64_json'] );
     }
 

--- a/inc/Generator.php
+++ b/inc/Generator.php
@@ -12,6 +12,9 @@ class Generator {
      * Schedule generation
      */
     public static function queue( $product_id, $fabric_name, $texture_id, $angles ) {
+        $logger  = wc_get_logger();
+        $context = [ 'source' => 'wc-fabric-mockups' ];
+        $logger->info( sprintf( 'Queueing generation for product %d fabric "%s"', $product_id, $fabric_name ), $context );
         as_enqueue_async_action( self::ACTION, [
             'product_id'  => $product_id,
             'fabric_name' => $fabric_name,
@@ -29,6 +32,10 @@ class Generator {
         $texture_id  = $args['texture_id'];
         $angles      = $args['angles'];
 
+        $logger  = wc_get_logger();
+        $context = [ 'source' => 'wc-fabric-mockups' ];
+        $logger->info( sprintf( 'Starting generation task for product %d fabric "%s"', $product_id, $fabric_name ), $context );
+
         $api_key = get_option( 'wcfm_api_key' );
         $master_id = get_option( 'wcfm_master_image' );
         $mask_id = get_option( 'wcfm_mask_image' );
@@ -41,10 +48,13 @@ class Generator {
         $image_ids = [];
 
         foreach ( $angles as $angle ) {
+            $logger->info( 'Generating angle ' . $angle, $context );
             $data = $adapter->generate( $texture_path, $angle );
             if ( ! $data ) {
+                $logger->error( 'Failed to generate angle ' . $angle, $context );
                 continue;
             }
+            $logger->info( 'Image generated for angle ' . $angle, $context );
 
             $upload_dir = wp_upload_dir();
             $filename   = 'mockup-' . sanitize_title( $fabric_name . '-' . $angle ) . '.png';
@@ -62,10 +72,15 @@ class Generator {
             $metadata = wp_generate_attachment_metadata( $attach_id, $filepath );
             wp_update_attachment_metadata( $attach_id, $metadata );
             $image_ids[] = $attach_id;
+            $logger->info( 'Stored attachment ' . $attach_id . ' for angle ' . $angle, $context );
         }
 
         if ( $image_ids ) {
+            $logger->info( 'Creating variation with generated images', $context );
             Woo::create_variation( $product_id, $fabric_name, $image_ids );
+            $logger->info( 'Generation completed for product ' . $product_id . ' fabric "' . $fabric_name . '"', $context );
+        } else {
+            $logger->error( 'No images generated for product ' . $product_id . ' fabric "' . $fabric_name . '"', $context );
         }
     }
 }

--- a/inc/Rest.php
+++ b/inc/Rest.php
@@ -29,6 +29,11 @@ class Rest {
 
         $angles = $all ? [ 'front', 'front-left', 'left', 'back', 'right', 'front-right' ] : [ 'front' ];
 
+        $logger  = wc_get_logger();
+        $context = [ 'source' => 'wc-fabric-mockups' ];
+        $logger->info( sprintf( 'Generation requested for product %d with fabric "%s" (texture %d)', $product_id, $fabric_name, $texture_id ), $context );
+        $logger->info( 'Angles queued: ' . implode( ', ', $angles ), $context );
+
         Generator::queue( $product_id, $fabric_name, $texture_id, $angles );
 
         return [ 'scheduled' => true ];

--- a/inc/Woo.php
+++ b/inc/Woo.php
@@ -29,6 +29,10 @@ class Woo {
             $variation->set_gallery_image_ids( array_slice( $image_ids, 1 ) );
         }
         $variation->save();
+
+        $logger  = wc_get_logger();
+        $context = [ 'source' => 'wc-fabric-mockups' ];
+        $logger->info( sprintf( 'Variation created for product %d fabric "%s"', $product_id, $fabric_name ), $context );
     }
 
     protected static function ensure_attribute( WC_Product_Variable $product, $fabric_name ) {


### PR DESCRIPTION
## Summary
- log image generation requests and queued angles
- record progress and errors during async generation, API calls, and variation creation

## Testing
- `php -l inc/Rest.php`
- `php -l inc/Generator.php`
- `php -l inc/ApiAdapter.php`
- `php -l inc/Woo.php`


------
https://chatgpt.com/codex/tasks/task_b_689b85a29c6483228eee209eb6e1161a