### PR TITLE
Add debug logging and admin log viewer

### DIFF
--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -54,6 +54,7 @@ class Admin {
 
     public static function settings_menu() {
         add_options_page( 'Fabric Mockups', 'Fabric Mockups', 'manage_options', 'wcfm-settings', [ __CLASS__, 'render_settings' ] );
+        add_options_page( 'Fabric Mockups Logs', 'Fabric Mockups Logs', 'manage_options', 'wcfm-logs', [ __CLASS__, 'render_logs' ] );
     }
 
     public static function register_settings() {
@@ -109,6 +110,39 @@ class Admin {
                 </table>
                 <?php submit_button(); ?>
             </form>
+            <p><a href="<?php echo esc_url( admin_url( 'options-general.php?page=wcfm-logs' ) ); ?>"><?php _e( 'View logs', 'wcfm' ); ?></a></p>
+        </div>
+        <?php
+    }
+
+    /**
+     * Render debug log page.
+     */
+    public static function render_logs() {
+        if ( isset( $_POST['wcfm_clear_logs'] ) && check_admin_referer( 'wcfm_clear_logs' ) ) {
+            Logger::clear();
+            echo '<div class="updated"><p>' . esc_html__( 'Logs cleared.', 'wcfm' ) . '</p></div>';
+        }
+
+        $logs = Logger::get_logs();
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Fabric Mockups Logs', 'wcfm' ); ?></h1>
+            <form method="post">
+                <?php wp_nonce_field( 'wcfm_clear_logs' ); ?>
+                <?php submit_button( __( 'Clear Logs', 'wcfm' ), 'secondary', 'wcfm_clear_logs', false ); ?>
+            </form>
+            <pre style="background:#fff;border:1px solid #ccc;padding:10px;max-height:500px;overflow:auto;">
+<?php
+if ( $logs ) {
+    foreach ( $logs as $entry ) {
+        echo esc_html( sprintf( '[%s] %s: %s', $entry['time'], strtoupper( $entry['level'] ), $entry['message'] ) ) . "\n";
+    }
+} else {
+    esc_html_e( 'No log entries found.', 'wcfm' );
+}
+?>
+            </pre>
         </div>
         <?php
     }

--- a/inc/ApiAdapter.php
+++ b/inc/ApiAdapter.php
@@ -33,14 +33,22 @@ class ApiAdapter {
         ];
 
         $payload = self::build_multipart( $body, $files, $boundary );
-
         Logger::info( 'Calling OpenAI API for angle ' . $angle );
+        Logger::info( 'OpenAI request payload: ' . wp_json_encode( $body ) );
+        Logger::info( 'OpenAI request images: master=' . basename( $this->master_image ) . ', mask=' . basename( $this->mask_image ) . ', texture=' . basename( $texture_path ) );
 
         $response = wp_remote_post( 'https://api.openai.com/v1/images/edits', [
             'headers' => $headers,
             'body'    => $payload,
             'timeout' => 60,
         ] );
+
+        if ( ! is_wp_error( $response ) ) {
+            $code    = wp_remote_retrieve_response_code( $response );
+            $body_snippet = substr( wp_remote_retrieve_body( $response ), 0, 200 );
+            Logger::info( 'OpenAI response code for angle ' . $angle . ': ' . $code );
+            Logger::info( 'OpenAI response body for angle ' . $angle . ': ' . $body_snippet );
+        }
 
         if ( is_wp_error( $response ) ) {
             Logger::error( 'OpenAI API error for angle ' . $angle . ': ' . $response->get_error_message() );

--- a/inc/Logger.php
+++ b/inc/Logger.php
@@ -11,6 +11,22 @@ class Logger {
             return;
         }
         wc_get_logger()->log( $level, $message, [ 'source' => 'wc-fabric-mockups' ] );
+
+        // Store log entry for display in admin debug page.
+        if ( false === get_option( 'wcfm_debug_log', false ) ) {
+            add_option( 'wcfm_debug_log', [], '', 'no' );
+        }
+        $logs   = get_option( 'wcfm_debug_log', [] );
+        $logs[] = [
+            'time'    => current_time( 'mysql' ),
+            'level'   => $level,
+            'message' => $message,
+        ];
+        // Keep the log size reasonable.
+        if ( count( $logs ) > 1000 ) {
+            $logs = array_slice( $logs, -1000 );
+        }
+        update_option( 'wcfm_debug_log', $logs, false );
     }
 
     public static function info( $message ) {
@@ -19,5 +35,21 @@ class Logger {
 
     public static function error( $message ) {
         self::log( 'error', $message );
+    }
+
+    /**
+     * Retrieve stored debug log entries.
+     *
+     * @return array
+     */
+    public static function get_logs() {
+        return get_option( 'wcfm_debug_log', [] );
+    }
+
+    /**
+     * Clear stored debug log entries.
+     */
+    public static function clear() {
+        delete_option( 'wcfm_debug_log' );
     }
 }

--- a/inc/Woo.php
+++ b/inc/Woo.php
@@ -34,6 +34,7 @@ class Woo {
     }
 
     protected static function ensure_attribute( WC_Product_Variable $product, $fabric_name ) {
+        Logger::info( 'Ensuring attribute for product ' . $product->get_id() );
         $attributes = $product->get_attributes();
         if ( ! isset( $attributes[ self::ATTRIBUTE_SLUG ] ) ) {
             $taxonomy = wc_sanitize_taxonomy_name( self::ATTRIBUTE_SLUG );
@@ -64,5 +65,6 @@ class Woo {
         if ( $term && ! in_array( $term->term_id, $terms, true ) ) {
             wp_set_object_terms( $product->get_id(), $term->term_id, self::ATTRIBUTE_SLUG, true );
         }
+        Logger::info( 'Attribute ensured for product ' . $product->get_id() );
     }
 }


### PR DESCRIPTION
## Summary
- Persist plugin activity to a custom debug log
- Add admin Logs page with option to clear entries
- Log OpenAI API request/response details and WooCommerce attribute setup

## Testing
- `php -l inc/Logger.php`
- `php -l inc/Admin.php`
- `php -l inc/ApiAdapter.php`
- `php -l inc/Woo.php`


------
https://chatgpt.com/codex/tasks/task_b_689b8a79c6f88322be5098fea9c7e7d3