### PR TITLE
Improve texture selection and request handling

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -14,6 +14,9 @@ jQuery(function($){
         frame.on('select', function(){
             var attachment = frame.state().get('selection').first().toJSON();
             $('#wcfm_texture_id').val( attachment.id );
+            $('#wcfm_texture_status').show();
+            var preview = '<img src="' + (attachment.sizes && attachment.sizes.thumbnail ? attachment.sizes.thumbnail.url : attachment.url) + '" style="max-width:100%;height:auto;" />';
+            $('#wcfm_texture_preview').html( preview );
         });
         frame.open();
     });
@@ -29,6 +32,7 @@ jQuery(function($){
         var btn = $(this).prop('disabled', true);
         fetch(WCFM.rest_url, {
             method: 'POST',
+            credentials: 'same-origin',
             headers: {
                 'Content-Type': 'application/json',
                 'X-WP-Nonce': WCFM.nonce
@@ -40,6 +44,9 @@ jQuery(function($){
                 all_angles: allAngles ? 1 : 0
             })
         }).then(function(resp){
+            if ( ! resp.ok ) {
+                return resp.json().then(function(err){ throw err; });
+            }
             return resp.json();
         }).then(function(){
             alert('Generation scheduled.');

--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -26,6 +26,8 @@ class Admin {
             <label><?php _e( 'Fabric texture', 'wcfm' ); ?></label><br/>
             <input type="hidden" id="wcfm_texture_id" />
             <button type="button" class="button" id="wcfm_upload_texture"><?php _e( 'Upload/Select', 'wcfm' ); ?></button>
+            <span id="wcfm_texture_status" class="dashicons dashicons-yes" style="display:none;color:#46b450;margin-left:5px;"></span>
+            <div id="wcfm_texture_preview" style="margin-top:10px;"></div>
         </p>
         <p>
             <label><input type="checkbox" id="wcfm_all_angles" checked /> <?php _e( 'Generate all 6 angles', 'wcfm' ); ?></label>

--- a/wc-fabric-mockups.php
+++ b/wc-fabric-mockups.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WooCommerce Fabric Mockups
  * Description: Generate chair fabric mockup images using OpenAI DALL·E and create WooCommerce variations.
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: ChatGPT
  */
 


### PR DESCRIPTION
## Summary
- show preview and checkmark after selecting fabric texture
- send REST requests with credentials and better error handling
- bump plugin version to 1.0.1

## Testing
- `php -l wc-fabric-mockups.php`
- `php -l inc/Admin.php`
- `node --check assets/admin.js`


------
https://chatgpt.com/codex/tasks/task_b_689b8cc25710832285e92bfd975180e0