### PR TITLE
Improve logging for mockup generation scheduling errors

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -51,8 +51,9 @@ jQuery(function($){
         }).then(function(){
             alert('Generation scheduled.');
             btn.prop('disabled', false);
-        }).catch(function(){
-            alert('Error scheduling generation');
+        }).catch(function(err){
+            var msg = (err && err.message) ? err.message : 'Error scheduling generation';
+            alert(msg);
             btn.prop('disabled', false);
         });
     });

--- a/inc/Rest.php
+++ b/inc/Rest.php
@@ -31,8 +31,10 @@ class Rest {
 
         Logger::info( sprintf( 'Generation requested for product %d with fabric "%s" (texture %d)', $product_id, $fabric_name, $texture_id ) );
         Logger::info( 'Angles queued: ' . implode( ', ', $angles ) );
-
-        Generator::queue( $product_id, $fabric_name, $texture_id, $angles );
+        $result = Generator::queue( $product_id, $fabric_name, $texture_id, $angles );
+        if ( is_wp_error( $result ) ) {
+            return new \WP_Error( 'wcfm_schedule', __( 'Failed to schedule generation: ', 'wcfm' ) . $result->get_error_message(), [ 'status' => 500 ] );
+        }
 
         return [ 'scheduled' => true ];
     }


### PR DESCRIPTION
## Summary
- Handle missing Action Scheduler and WP_Error results when queueing mockup generation
- Surface scheduling failures to REST client and display messages in admin UI

## Testing
- `php -l inc/Generator.php inc/Rest.php`
- `node --check assets/admin.js`


------
https://chatgpt.com/codex/tasks/task_b_689b9294081883229b0bacdfd575b28c