### PR TITLE
Remove master and mask image settings

### DIFF
--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -58,8 +58,6 @@ class Admin {
             add_option( 'wcfm_api_key', '', '', 'no' );
         }
         register_setting( 'wcfm-settings', 'wcfm_api_key', [ 'sanitize_callback' => 'sanitize_text_field' ] );
-        register_setting( 'wcfm-settings', 'wcfm_master_image', [ 'sanitize_callback' => 'absint' ] );
-        register_setting( 'wcfm-settings', 'wcfm_mask_image', [ 'sanitize_callback' => 'absint' ] );
         if ( false === get_option( 'wcfm_enable_logging', false ) ) {
             add_option( 'wcfm_enable_logging', 0, '', 'no' );
         }
@@ -78,22 +76,6 @@ class Admin {
                     <tr>
                         <th scope="row"><label for="wcfm_api_key"><?php _e( 'OpenAI API Key', 'wcfm' ); ?></label></th>
                         <td><input type="text" name="wcfm_api_key" id="wcfm_api_key" value="<?php echo esc_attr( get_option( 'wcfm_api_key' ) ); ?>" class="regular-text" /></td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><label for="wcfm_master_image"><?php _e( 'Master chair image', 'wcfm' ); ?></label></th>
-                        <td>
-                            <?php $master = get_option( 'wcfm_master_image' ); ?>
-                            <input type="number" name="wcfm_master_image" id="wcfm_master_image" value="<?php echo esc_attr( $master ); ?>" />
-                            <p class="description"><?php _e( 'Attachment ID of the base chair image.', 'wcfm' ); ?></p>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><label for="wcfm_mask_image"><?php _e( 'Mask image', 'wcfm' ); ?></label></th>
-                        <td>
-                            <?php $mask = get_option( 'wcfm_mask_image' ); ?>
-                            <input type="number" name="wcfm_mask_image" id="wcfm_mask_image" value="<?php echo esc_attr( $mask ); ?>" />
-                            <p class="description"><?php _e( 'Attachment ID of PNG mask with transparent upholstery.', 'wcfm' ); ?></p>
-                        </td>
                     </tr>
                     <tr>
                         <th scope="row"><label for="wcfm_enable_logging"><?php _e( 'Enable logging', 'wcfm' ); ?></label></th>

--- a/inc/ApiAdapter.php
+++ b/inc/ApiAdapter.php
@@ -3,16 +3,12 @@ namespace WC_Fabric_Mockups;
 
 class ApiAdapter {
     protected $api_key;
-    protected $master_image;
-    protected $mask_image;
 
-    public function __construct( $api_key, $master_image, $mask_image ) {
-        $this->api_key      = $api_key;
-        $this->master_image = $master_image;
-        $this->mask_image   = $mask_image;
+    public function __construct( $api_key ) {
+        $this->api_key = $api_key;
     }
 
-    public function generate( $texture_path ) {
+    public function generate( $master_image, $texture_path ) {
         $prompt = 'High-end studio photo of the same dining chair model, replace upholstery with fabric from the reference texture image, seamless light gray background with soft shadows.';
         $body   = [
             'model'  => 'gpt-image-1',
@@ -27,15 +23,14 @@ class ApiAdapter {
         ];
 
         $files = [
-            'image'       => $this->master_image,
-            'mask'        => $this->mask_image,
-            'image[]'     => $texture_path,
+            'image'   => $master_image,
+            'image[]' => $texture_path,
         ];
 
         $payload = self::build_multipart( $body, $files, $boundary );
         Logger::info( 'Calling OpenAI API' );
         Logger::info( 'OpenAI request payload: ' . wp_json_encode( $body ) );
-        Logger::info( 'OpenAI request images: master=' . basename( $this->master_image ) . ', mask=' . basename( $this->mask_image ) . ', texture=' . basename( $texture_path ) );
+        Logger::info( 'OpenAI request images: master=' . basename( $master_image ) . ', texture=' . basename( $texture_path ) );
 
         $response = wp_remote_post( 'https://api.openai.com/v1/images/edits', [
             'headers' => $headers,

--- a/inc/Generator.php
+++ b/inc/Generator.php
@@ -48,9 +48,7 @@ class Generator {
         $texture_id = $args['texture_id'];
         Logger::info( sprintf( 'Starting generation task for product %d', $product_id ) );
 
-        $api_key   = get_option( 'wcfm_api_key' );
-        $mask_id   = get_option( 'wcfm_mask_image' );
-        $mask_path = get_attached_file( $mask_id );
+        $api_key      = get_option( 'wcfm_api_key' );
         $texture_path = get_attached_file( $texture_id );
 
         $product = wc_get_product( $product_id );
@@ -68,8 +66,8 @@ class Generator {
                 Logger::error( 'Missing file for attachment ' . $orig_id );
                 continue;
             }
-            $adapter = new ApiAdapter( $api_key, $master_path, $mask_path );
-            $data = $adapter->generate( $texture_path );
+            $adapter = new ApiAdapter( $api_key );
+            $data    = $adapter->generate( $master_path, $texture_path );
             if ( ! $data ) {
                 Logger::error( 'Failed to generate image for attachment ' . $orig_id );
                 continue;


### PR DESCRIPTION
## Summary
- eliminate master chair and mask image settings from plugin
- generate mockups directly from product images and textures
- simplify API adapter to accept master and texture inputs only

## Testing
- `php -l inc/ApiAdapter.php`
- `php -l inc/Generator.php`
- `php -l inc/Admin.php`


------
https://chatgpt.com/codex/tasks/task_b_689b975122388322b7a0792097e708f7