### PR TITLE
Fix product ID handling in async generation

### DIFF
--- a/inc/Generator.php
+++ b/inc/Generator.php
@@ -5,7 +5,7 @@ class Generator {
     const ACTION = 'wcfm_generate_task';
 
     public static function init() {
-        add_action( self::ACTION, [ __CLASS__, 'process' ], 10, 1 );
+        add_action( self::ACTION, [ __CLASS__, 'process' ], 10, 2 );
     }
 
     /**
@@ -43,9 +43,7 @@ class Generator {
     /**
      * Process scheduled action
      */
-    public static function process( $args ) {
-        $product_id = $args['product_id'];
-        $texture_id = $args['texture_id'];
+    public static function process( $product_id, $texture_id ) {
         Logger::info( sprintf( 'Starting generation task for product %d', $product_id ) );
 
         $api_key      = get_option( 'wcfm_api_key' );


### PR DESCRIPTION
## Summary
- ensure scheduled generation passes product and texture IDs correctly
- prevent "Product not found" errors during generation

## Testing
- `php -l inc/Generator.php`
- `php -l inc/Rest.php`


------
https://chatgpt.com/codex/tasks/task_b_689baf363ed88322b8d6d3a9a65f4960