### PR TITLE
Use mask parameter for OpenAI image edits

### DIFF
--- a/inc/ApiAdapter.php
+++ b/inc/ApiAdapter.php
@@ -8,7 +8,7 @@ class ApiAdapter {
         $this->api_key = $api_key;
     }
 
-    public function generate( $master_image, $texture_path ) {
+    public function generate( $master_image, $mask_path = null ) {
         $prompt = 'High-end studio photo of the same dining chair model, replace upholstery with fabric from the reference texture image, seamless light gray background with soft shadows.';
         $body   = [
             'model'  => 'gpt-image-1',
@@ -23,14 +23,20 @@ class ApiAdapter {
         ];
 
         $files = [
-            'image'   => $master_image,
-            'image[]' => $texture_path,
+            'image[]' => $master_image,
         ];
+        if ( $mask_path ) {
+            $files['mask'] = $mask_path;
+        }
 
         $payload = self::build_multipart( $body, $files, $boundary );
         Logger::info( 'Calling OpenAI API' );
         Logger::info( 'OpenAI request payload: ' . wp_json_encode( $body ) );
-        Logger::info( 'OpenAI request images: master=' . basename( $master_image ) . ', texture=' . basename( $texture_path ) );
+        $log_msg = 'OpenAI request images: master=' . basename( $master_image );
+        if ( $mask_path ) {
+            $log_msg .= ', mask=' . basename( $mask_path );
+        }
+        Logger::info( $log_msg );
 
         $response = wp_remote_post( 'https://api.openai.com/v1/images/edits', [
             'headers' => $headers,

--- a/inc/Generator.php
+++ b/inc/Generator.php
@@ -47,7 +47,7 @@ class Generator {
         Logger::info( sprintf( 'Starting generation task for product %d', $product_id ) );
 
         $api_key      = get_option( 'wcfm_api_key' );
-        $texture_path = get_attached_file( $texture_id );
+        $mask_path    = get_attached_file( $texture_id );
 
         $product = wc_get_product( $product_id );
         if ( ! $product ) {
@@ -65,7 +65,7 @@ class Generator {
                 continue;
             }
             $adapter = new ApiAdapter( $api_key );
-            $data    = $adapter->generate( $master_path, $texture_path );
+            $data    = $adapter->generate( $master_path, $mask_path );
             if ( ! $data ) {
                 Logger::error( 'Failed to generate image for attachment ' . $orig_id );
                 continue;


### PR DESCRIPTION
## Summary
- Send the original chair image as `image[]` and optionally attach a `mask` instead of a second `image` value
- Pass mask path through the generator to avoid duplicate `image` parameters that caused API 400 errors

## Testing
- `php -l inc/ApiAdapter.php`
- `php -l inc/Generator.php`


------
https://chatgpt.com/codex/tasks/task_b_689bb18ec26c8322be2f1880363de5d0