### PR TITLE
Fix job start error by sending JSON payload

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -97,7 +97,9 @@
                 method: 'POST',
                 url: CTS.rest.root + '/process',
                 beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', CTS.rest.nonce); },
-                data: data
+                data: JSON.stringify(data),
+                contentType: 'application/json',
+                processData: false
             }).done(function(response){
                 renderRows(response.items || []);
                 if (response.job_id){


### PR DESCRIPTION
## Summary
- Ensure AJAX request for processing job sends JSON payload with proper headers

## Testing
- `npm test` *(fails: missing package.json)*
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_b_689bbab37c788322a906673b515b321e