### PR TITLE
Add OpenAI API call with error handling

### DIFF
--- a/includes/class-openai-client.php
+++ b/includes/class-openai-client.php
@@ -15,6 +15,13 @@ class CTS_OpenAI_Client {
     }
 
     public function image_edit( $params ) {
+        if ( empty( $this->api_key ) ) {
+            return new WP_Error(
+                'cts_missing_api_key',
+                __( 'OpenAI API key is not set', 'chair-texture-swap' )
+            );
+        }
+
         $endpoint = 'https://api.openai.com/v1/images/edits';
         $args = array(
             'timeout' => $this->timeout,


### PR DESCRIPTION
## Summary
- Call OpenAI image edit API during processing
- Report detailed errors when API key missing or request fails

## Testing
- `php -l includes/class-openai-client.php`
- `php -l includes/class-processor.php`


------
https://chatgpt.com/codex/tasks/task_b_689bbf4fa3048322899569708f5ffe10