### PR TITLE
Fix OpenAI edit request content type

### DIFF
--- a/includes/class-openai-client.php
+++ b/includes/class-openai-client.php
@@ -27,6 +27,7 @@ class CTS_OpenAI_Client {
             'timeout' => $this->timeout,
             'headers' => array(
                 'Authorization' => 'Bearer ' . $this->api_key,
+                'Content-Type'  => 'multipart/form-data',
             ),
             'body'    => $params,
         );


### PR DESCRIPTION
## Summary
- ensure OpenAI image edit requests use multipart/form-data content type

## Testing
- `php -l includes/class-openai-client.php`


------
https://chatgpt.com/codex/tasks/task_b_689bc375ed1c83229c916bf74ea05e96