### PR TITLE
Fix multipart request handling for OpenAI image edits

### DIFF
--- a/includes/class-openai-client.php
+++ b/includes/class-openai-client.php
@@ -23,11 +23,14 @@ class CTS_OpenAI_Client {
         }
 
         $endpoint = 'https://api.openai.com/v1/images/edits';
+
+        // Ensure the required model parameter is always sent.
+        $params['model'] = $this->model;
+
         $args = array(
             'timeout' => $this->timeout,
             'headers' => array(
                 'Authorization' => 'Bearer ' . $this->api_key,
-                'Content-Type'  => 'multipart/form-data',
             ),
             'body'    => $params,
         );


### PR DESCRIPTION
## Summary
- ensure OpenAI requests include required model parameter
- let WordPress set multipart boundaries instead of hardcoding Content-Type

## Testing
- `php -l includes/class-openai-client.php`


------
https://chatgpt.com/codex/tasks/task_b_689bc56a04688322b526f8075052d464