### PR TITLE
Ensure OpenAI image edits use multipart form data

### DIFF
--- a/includes/class-openai-client.php
+++ b/includes/class-openai-client.php
@@ -14,6 +14,39 @@ class CTS_OpenAI_Client {
         $this->timeout = (int) get_option( 'cts_timeout', 30 );
     }
 
+    /**
+     * Build multipart/form-data body with boundary.
+     *
+     * @param array  $params   Fields and files to send.
+     * @param string $boundary Generated boundary (passed by reference).
+     * @return string
+     */
+    private function build_multipart_body( $params, &$boundary ) {
+        $boundary = wp_generate_uuid4();
+        $eol      = "\r\n";
+        $body     = '';
+
+        foreach ( $params as $name => $content ) {
+            $body .= '--' . $boundary . $eol;
+            if ( $content instanceof CURLFile ) {
+                $filename = basename( $content->getFilename() );
+                $mime     = $content->getMimeType();
+                if ( empty( $mime ) ) {
+                    $mime = 'application/octet-stream';
+                }
+                $body .= 'Content-Disposition: form-data; name="' . $name . '"; filename="' . $filename . '"' . $eol;
+                $body .= 'Content-Type: ' . $mime . $eol . $eol;
+                $body .= file_get_contents( $content->getFilename() ) . $eol;
+            } else {
+                $body .= 'Content-Disposition: form-data; name="' . $name . '"' . $eol . $eol;
+                $body .= $content . $eol;
+            }
+        }
+
+        $body .= '--' . $boundary . '--' . $eol;
+        return $body;
+    }
+
     public function image_edit( $params ) {
         if ( empty( $this->api_key ) ) {
             return new WP_Error(
@@ -27,13 +60,17 @@ class CTS_OpenAI_Client {
         // Ensure the required model parameter is always sent.
         $params['model'] = $this->model;
 
+        $body = $this->build_multipart_body( $params, $boundary );
+
         $args = array(
             'timeout' => $this->timeout,
             'headers' => array(
                 'Authorization' => 'Bearer ' . $this->api_key,
+                'Content-Type'  => 'multipart/form-data; boundary=' . $boundary,
             ),
-            'body'    => $params,
+            'body'    => $body,
         );
+
         return wp_remote_post( $endpoint, $args );
     }
 }


### PR DESCRIPTION
## Summary
- build multipart/form-data bodies for image edit requests
- include appropriate Content-Type header so OpenAI accepts uploads

## Testing
- `php -l includes/class-openai-client.php`

------
https://chatgpt.com/codex/tasks/task_b_689bc86f72a88322a45f90024f4f1b4b