### PR TITLE
Add option to use base image dimensions for output

### DIFF
--- a/includes/class-processor.php
+++ b/includes/class-processor.php
@@ -38,17 +38,27 @@ class CTS_Processor {
             $prompt .= ' (' . implode( ', ', array_map( 'sanitize_text_field', $areas ) ) . ')';
         }
 
-        $allowed_sizes = array( 256, 512, 768, 1024 );
-        $size          = (int) $size;
-        if ( ! in_array( $size, $allowed_sizes, true ) ) {
-            $size = 1024;
+        if ( 'base' === $size ) {
+            $info = getimagesize( $base_path );
+            if ( $info ) {
+                $size_param = $info[0] . 'x' . $info[1];
+            } else {
+                $size_param = '1024x1024';
+            }
+        } else {
+            $allowed_sizes = array( 256, 512, 768, 1024 );
+            $size          = (int) $size;
+            if ( ! in_array( $size, $allowed_sizes, true ) ) {
+                $size = 1024;
+            }
+            $size_param = $size . 'x' . $size;
         }
 
         $texture_path = get_attached_file( $texture_id );
 
         $params = array(
             'prompt' => $prompt,
-            'size'   => $size . 'x' . $size,
+            'size'   => $size_param,
         );
 
         $base_mime = get_post_mime_type( $base_id );

--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -44,10 +44,13 @@ class CTS_REST {
         $texture_id = isset( $params['texture_image_id'] ) ? intval( $params['texture_image_id'] ) : 0;
         $areas = isset( $params['areas'] ) ? array_map( 'sanitize_text_field', (array) $params['areas'] ) : array();
 
-        $allowed_sizes = array( 256, 512, 768, 1024 );
-        $size          = isset( $params['size'] ) ? intval( $params['size'] ) : 1024;
-        if ( ! in_array( $size, $allowed_sizes, true ) ) {
-            $size = 1024;
+        $size = isset( $params['size'] ) ? $params['size'] : 1024;
+        if ( 'base' !== $size ) {
+            $allowed_sizes = array( 256, 512, 768, 1024 );
+            $size          = intval( $size );
+            if ( ! in_array( $size, $allowed_sizes, true ) ) {
+                $size = 1024;
+            }
         }
 
         $prompt = sanitize_textarea_field( $params['prompt_overrides'] ?? '' );

--- a/views/page-process.php
+++ b/views/page-process.php
@@ -24,6 +24,7 @@
                 <option value="1024">1024</option>
                 <option value="768">768</option>
                 <option value="512">512</option>
+                <option value="base"><?php _e( 'Base image size', 'chair-texture-swap' ); ?></option>
             </select>
         </p>
         <p>


### PR DESCRIPTION
## Summary
- Allow choosing base image size in processing form
- Support `base` size through REST API and processor
- Compute output size from base image dimensions when requested

## Testing
- `php -l includes/class-rest.php`
- `php -l includes/class-processor.php`
- `php -l views/page-process.php`


------
https://chatgpt.com/codex/tasks/task_b_689c8706ab60832286e310adf26e9d11