### PR TITLE
Increase default timeout and execution limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ WordPress plugin that batches chair upholstery texture swaps using the OpenAI im
 
 ### Timeout handling
 
-The plugin now uses a 60 second default timeout for requests to the OpenAI API and retries once with a longer timeout if the initial request fails with a `cURL error 28`. You can adjust the timeout value from the plugin settings page.
+The plugin now uses a 300 second default timeout for requests to the OpenAI API and retries once with a longer timeout if the initial request fails with a `cURL error 28`. The PHP execution time limit is increased as well so large image jobs have adequate time to finish. You can adjust the timeout value from the plugin settings page.

--- a/includes/class-openai-client.php
+++ b/includes/class-openai-client.php
@@ -14,7 +14,7 @@ class CTS_OpenAI_Client {
         // Ensure a sane minimum timeout so large image requests have
         // enough time to complete. Users may override this value via the
         // settings screen, but we never allow less than 60 seconds.
-        $option_timeout = (int) get_option( 'cts_timeout', 60 );
+        $option_timeout = (int) get_option( 'cts_timeout', 300 );
         $this->timeout  = max( 60, $option_timeout );
     }
 
@@ -65,6 +65,11 @@ class CTS_OpenAI_Client {
         $params['model'] = $this->model;
 
         $body = $this->build_multipart_body( $params, $boundary );
+
+        // Bump PHP execution limits to give long-running image requests a
+        // better chance of completing before the server kills the process.
+        @set_time_limit( $this->timeout * 2 );
+        @ini_set( 'max_execution_time', $this->timeout * 2 );
 
         $args = array(
             'timeout' => $this->timeout,

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -29,7 +29,7 @@ class CTS_Settings {
     }
 
     public function field_timeout() {
-        echo '<input type="number" name="cts_timeout" value="' . esc_attr( get_option( 'cts_timeout', 60 ) ) . '" class="small-text" />';
+        echo '<input type="number" name="cts_timeout" min="60" value="' . esc_attr( get_option( 'cts_timeout', 300 ) ) . '" class="small-text" />';
     }
 }
 


### PR DESCRIPTION
## Summary
- raise default API timeout to 300 seconds and expand PHP execution limit for longer image jobs
- expose higher timeout in settings UI with minimum field value
- document new default and execution limit behavior

## Testing
- `php -l includes/class-openai-client.php`
- `php -l includes/class-settings.php`


------
https://chatgpt.com/codex/tasks/task_b_689c89017bfc8322a5c34cc92a79adbf