### PR TITLE
Support new OpenAI image size options

### DIFF
--- a/includes/class-processor.php
+++ b/includes/class-processor.php
@@ -38,20 +38,11 @@ class CTS_Processor {
             $prompt .= ' (' . implode( ', ', array_map( 'sanitize_text_field', $areas ) ) . ')';
         }
 
-        if ( 'base' === $size ) {
-            $info = getimagesize( $base_path );
-            if ( $info ) {
-                $size_param = $info[0] . 'x' . $info[1];
-            } else {
-                $size_param = '1024x1024';
-            }
+        $allowed_sizes = array( '1024x1024', '1024x1536', '1536x1024', 'auto' );
+        if ( ! in_array( $size, $allowed_sizes, true ) ) {
+            $size_param = '1024x1024';
         } else {
-            $allowed_sizes = array( 256, 512, 768, 1024 );
-            $size          = (int) $size;
-            if ( ! in_array( $size, $allowed_sizes, true ) ) {
-                $size = 1024;
-            }
-            $size_param = $size . 'x' . $size;
+            $size_param = $size;
         }
 
         $texture_path = get_attached_file( $texture_id );

--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -44,13 +44,10 @@ class CTS_REST {
         $texture_id = isset( $params['texture_image_id'] ) ? intval( $params['texture_image_id'] ) : 0;
         $areas = isset( $params['areas'] ) ? array_map( 'sanitize_text_field', (array) $params['areas'] ) : array();
 
-        $size = isset( $params['size'] ) ? $params['size'] : 1024;
-        if ( 'base' !== $size ) {
-            $allowed_sizes = array( 256, 512, 768, 1024 );
-            $size          = intval( $size );
-            if ( ! in_array( $size, $allowed_sizes, true ) ) {
-                $size = 1024;
-            }
+        $size = isset( $params['size'] ) ? sanitize_text_field( $params['size'] ) : '1024x1024';
+        $allowed_sizes = array( '1024x1024', '1024x1536', '1536x1024', 'auto' );
+        if ( ! in_array( $size, $allowed_sizes, true ) ) {
+            $size = '1024x1024';
         }
 
         $prompt = sanitize_textarea_field( $params['prompt_overrides'] ?? '' );

--- a/views/page-process.php
+++ b/views/page-process.php
@@ -21,10 +21,10 @@
         <p>
             <label for="cts-size"><?php _e( 'Output Size', 'chair-texture-swap' ); ?></label>
             <select id="cts-size" name="size">
-                <option value="1024">1024</option>
-                <option value="768">768</option>
-                <option value="512">512</option>
-                <option value="base"><?php _e( 'Base image size', 'chair-texture-swap' ); ?></option>
+                <option value="1024x1024">1024x1024</option>
+                <option value="1024x1536">1024x1536</option>
+                <option value="1536x1024">1536x1024</option>
+                <option value="auto"><?php _e( 'Auto', 'chair-texture-swap' ); ?></option>
             </select>
         </p>
         <p>


### PR DESCRIPTION
## Summary
- update processor and REST endpoint to accept new image size options or auto
- refresh admin UI with size choices `1024x1024`, `1024x1536`, `1536x1024`, and `auto`

## Testing
- `php -l includes/class-processor.php`
- `php -l includes/class-rest.php`
- `php -l views/page-process.php`


------
https://chatgpt.com/codex/tasks/task_b_689c8ab5be688322832f34ddfd7c8ccd