### PR TITLE
Process jobs asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ WordPress plugin that batches chair upholstery texture swaps using the OpenAI im
 ### Timeout handling
 
 The plugin now uses a 300 second default timeout for requests to the OpenAI API and retries once with a longer timeout if the initial request fails with a `cURL error 28`. The PHP execution time limit is increased as well so large image jobs have adequate time to finish. You can adjust the timeout value from the plugin settings page.
+
+### Background processing
+
+Image jobs are processed asynchronously using WP-Cron. The REST endpoint quickly returns a job ID while processing continues in the background, so tasks can finish even if the browser leaves the page.


### PR DESCRIPTION
## Summary
- process image swaps asynchronously using WP-Cron to avoid request timeouts
- document background processing behavior in README

## Testing
- `php -l includes/class-rest.php`
- `php -l chair-texture-swap.php`


------
https://chatgpt.com/codex/tasks/task_b_689cbd5cc1a8832299c827907da3785b