### PR TITLE
Fix REST calls for legacy jQuery

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -101,7 +101,7 @@
 
                 function pollJob(jobId, index){
                     $.ajax({
-                        method: 'GET',
+                        type: 'GET',
                         url: apiRoot + '/status/' + jobId,
                         beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', CTS.rest.nonce); }
                     }).done(function(resp){
@@ -132,7 +132,7 @@
                 }
 
                 $.ajax({
-                    method: 'POST',
+                    type: 'POST',
                     url: apiRoot + '/process',
                     beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', CTS.rest.nonce); },
                     data: JSON.stringify(data),


### PR DESCRIPTION
## Summary
- Use `type` instead of `method` in jQuery AJAX requests to ensure correct HTTP verbs.

## Testing
- `node --check assets/admin.js`

------
https://chatgpt.com/codex/tasks/task_b_689cc398a3e08322a480753e1126e779