### PR TITLE
Ensure sequential filenames and preserve image text

### DIFF
--- a/includes/class-processor.php
+++ b/includes/class-processor.php
@@ -37,6 +37,7 @@ class CTS_Processor {
         if ( ! empty( $areas ) ) {
             $prompt .= ' (' . implode( ', ', array_map( 'sanitize_text_field', $areas ) ) . ')';
         }
+        $prompt .= ' ' . __( 'Do not alter or modify any existing text or letters in the image.', 'chair-texture-swap' );
 
         $allowed_sizes = array( '1024x1024', '1024x1536', '1536x1024', 'auto' );
         if ( ! in_array( $size, $allowed_sizes, true ) ) {

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -5,9 +5,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 function cts_save_image_to_media_library( $binary, $base_id, $texture_id, $job_id ) {
     $upload_dir = wp_upload_dir();
-    $base_name  = pathinfo( get_attached_file( $base_id ), PATHINFO_FILENAME );
-    $filename   = sanitize_file_name( $base_name . '-texture-swap-' . current_time( 'Ymd-His' ) . '.png' );
-    $filepath   = trailingslashit( $upload_dir['path'] ) . $filename;
+    $base_name = pathinfo( get_attached_file( $base_id ), PATHINFO_FILENAME );
+    $base_dir  = trailingslashit( $upload_dir['path'] );
+    $counter   = 1;
+    do {
+        $name      = $base_name . '-' . $counter;
+        $png_path  = $base_dir . sanitize_file_name( $name . '.png' );
+        $jpg_path  = $base_dir . sanitize_file_name( $name . '.jpg' );
+        $counter++;
+    } while ( file_exists( $png_path ) || file_exists( $jpg_path ) );
+
+    $filename = basename( $png_path );
+    $filepath = $png_path;
 
     if ( ! wp_mkdir_p( $upload_dir['path'] ) ) {
         return new WP_Error( 'cts_upload_dir', __( 'Upload directory not writable', 'chair-texture-swap' ) );

--- a/views/page-process.php
+++ b/views/page-process.php
@@ -29,7 +29,7 @@
         </p>
         <p>
             <label for="cts-prompt"><?php _e( 'AI Prompt', 'chair-texture-swap' ); ?></label><br>
-            <textarea id="cts-prompt" name="prompt_overrides" rows="4" cols="50"><?php echo esc_textarea( __( "Replace only the chair’s fabric upholstery with the provided texture reference.\nKeep frame, legs, lighting, shadows, composition and perspective unchanged.\nPreserve seams, stitch lines, realistic fabric behavior, and scale of the pattern.\nNo other edits besides the fabric swap.", 'chair-texture-swap' ) ); ?></textarea>
+            <textarea id="cts-prompt" name="prompt_overrides" rows="4" cols="50"><?php echo esc_textarea( __( "Replace only the chair’s fabric upholstery with the provided texture reference.\nKeep frame, legs, lighting, shadows, composition and perspective unchanged.\nPreserve seams, stitch lines, realistic fabric behavior, and scale of the pattern.\nNo other edits besides the fabric swap.\nDo not alter, add, or remove any text or letters present in the image.", 'chair-texture-swap' ) ); ?></textarea>
         </p>
         <p>
             <button type="submit" class="button button-primary"><?php _e( 'Start Processing', 'chair-texture-swap' ); ?></button>


### PR DESCRIPTION
## Summary
- Name generated images after their base files using the first available number
- Append instructions preventing text/letter changes in AI prompts
- Update default prompt text to specify not altering on-image text

## Testing
- `php -l includes/class-processor.php`
- `php -l includes/helpers.php`
- `php -l views/page-process.php`


------
https://chatgpt.com/codex/tasks/task_b_689cc569c2648322a8f908b8becff45b