### PR TITLE
Fix REST job ID pattern for Chair Texture Swap plugin

### DIFF
--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -21,13 +21,13 @@ class CTS_REST {
             'permission_callback' => array( $this, 'permissions_check' ),
         ) );
 
-        register_rest_route( 'chair-texture-swap/v1', '/status/(?P<job_id>[a-zA-Z0-9-]+)', array(
+        register_rest_route( 'chair-texture-swap/v1', '/status/(?P<job_id>[a-zA-Z0-9_.-]+)', array(
             'methods'  => 'GET',
             'callback' => array( $this, 'status' ),
             'permission_callback' => array( $this, 'permissions_check' ),
         ) );
 
-        register_rest_route( 'chair-texture-swap/v1', '/cancel/(?P<job_id>[a-zA-Z0-9-]+)', array(
+        register_rest_route( 'chair-texture-swap/v1', '/cancel/(?P<job_id>[a-zA-Z0-9_.-]+)', array(
             'methods'  => 'POST',
             'callback' => array( $this, 'cancel' ),
             'permission_callback' => array( $this, 'permissions_check' ),


### PR DESCRIPTION
## Summary
- allow underscores and dots in job ID for status and cancel REST endpoints so requests succeed

## Testing
- `php -l includes/class-rest.php`


------
https://chatgpt.com/codex/tasks/task_b_689cc7c1c6308322a69d9a1ce2aa98bd