### PR TITLE
Add image quality selection with size estimate

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -3,6 +3,14 @@
         var baseFrame, textureFrame;
         const apiRoot = CTS.rest.root.replace(/\/$/, '');
 
+        function updateEstimate(){
+            var q = parseInt($('#cts-quality').val(), 10) || 0;
+            var est = q * 100;
+            $('#cts-quality-estimate').text(est ? est + ' KB' : '');
+        }
+        $('#cts-quality').on('change', updateEstimate);
+        updateEstimate();
+
         $('#cts-select-base').on('click', function(e){
             e.preventDefault();
             if (!baseFrame) {
@@ -77,6 +85,7 @@
             var areas = $('input[name="areas[]"]:checked').map(function(){ return $(this).val(); }).get();
             var size = $('#cts-size').val();
             var prompt = $('#cts-prompt').val();
+            var quality = $('#cts-quality').val();
 
             var items = baseIds.map(function(id){
                 return { id: id, status: 'queued' };
@@ -96,7 +105,8 @@
                     texture_image_id: textureId,
                     areas: areas,
                     size: size,
-                    prompt_overrides: prompt
+                    prompt_overrides: prompt,
+                    quality: quality
                 };
 
                 function pollJob(jobId, index){

--- a/includes/class-processor.php
+++ b/includes/class-processor.php
@@ -12,15 +12,15 @@ class CTS_Processor {
         $this->logger = $logger;
     }
 
-    public function process_job( $base_ids, $texture_id, $areas, $size, $prompt_overrides ) {
+    public function process_job( $base_ids, $texture_id, $areas, $size, $quality, $prompt_overrides ) {
         $results = array();
         foreach ( $base_ids as $base_id ) {
-            $results[] = $this->process_single_image( $base_id, $texture_id, $areas, $size, $prompt_overrides );
+            $results[] = $this->process_single_image( $base_id, $texture_id, $areas, $size, $quality, $prompt_overrides );
         }
         return $results;
     }
 
-    public function process_single_image( $base_id, $texture_id, $areas, $size, $prompt_overrides ) {
+    public function process_single_image( $base_id, $texture_id, $areas, $size, $quality, $prompt_overrides ) {
         $this->logger->info( 'Processing image', array( 'context' => $base_id ) );
 
         $base_path = get_attached_file( $base_id );
@@ -111,7 +111,7 @@ class CTS_Processor {
         }
 
         $binary    = base64_decode( $data['data'][0]['b64_json'] );
-        $result_id = cts_save_image_to_media_library( $binary, $base_id, $texture_id, uniqid( 'cts_', true ) );
+        $result_id = cts_save_image_to_media_library( $binary, $base_id, $texture_id, uniqid( 'cts_', true ), $quality );
 
         if ( is_wp_error( $result_id ) ) {
             $message = $result_id->get_error_message();

--- a/views/page-process.php
+++ b/views/page-process.php
@@ -28,6 +28,15 @@
             </select>
         </p>
         <p>
+            <label for="cts-quality"><?php _e( 'Output Quality', 'chair-texture-swap' ); ?></label>
+            <select id="cts-quality" name="quality">
+                <?php for ( $i = 1; $i <= 10; $i++ ) : ?>
+                    <option value="<?php echo $i; ?>"><?php echo $i; ?></option>
+                <?php endfor; ?>
+            </select>
+            <span id="cts-quality-estimate"></span>
+        </p>
+        <p>
             <label for="cts-prompt"><?php _e( 'AI Prompt', 'chair-texture-swap' ); ?></label><br>
             <textarea id="cts-prompt" name="prompt_overrides" rows="4" cols="50"><?php echo esc_textarea( __( "Replace only the chair’s fabric upholstery with the provided texture reference.\nKeep frame, legs, lighting, shadows, composition and perspective unchanged.\nPreserve seams, stitch lines, realistic fabric behavior, and scale of the pattern.\nNo other edits besides the fabric swap.\nDo not alter, add, or remove any text or letters present in the image.", 'chair-texture-swap' ) ); ?></textarea>
         </p>


### PR DESCRIPTION
## Summary
- allow selecting output quality from 1-10 in admin form with estimated KB size
- send chosen quality through REST API and processing pipeline
- compress saved images based on selected quality target size

## Testing
- `php -l includes/class-rest.php`
- `php -l includes/class-processor.php`
- `php -l includes/helpers.php`
- `php -l views/page-process.php`
- `node --check assets/admin.js`


------
https://chatgpt.com/codex/tasks/task_b_689cc99727408322a8f5cfea450b0dfe